### PR TITLE
Add async Parquet export for SCID files

### DIFF
--- a/tests/test_async_scid_reader.py
+++ b/tests/test_async_scid_reader.py
@@ -11,6 +11,7 @@ from sierrapy.parser.scid_parse import RollPeriod, ScidContractInfo
 
 
 _created_readers: list["_DummyFastReader"] = []
+_parquet_exports: list[tuple[str, str, dict]] = []
 
 
 class _DummyFastReader:
@@ -56,6 +57,21 @@ class _DummyFastReader:
         return frame
 
 
+class _DummyParquetFastReader:
+    def __init__(self, path: str) -> None:
+        self.path = path
+        Path(path).touch()
+
+    def export_to_parquet_optimized(self, out_path: str, **kwargs):
+        record = (self.path, out_path, kwargs)
+        _parquet_exports.append(record)
+        return {
+            "source": self.path,
+            "output": out_path,
+            "kwargs": kwargs,
+        }
+
+
 def test_read_period_limits_contract_window(monkeypatch):
     _created_readers.clear()
 
@@ -79,11 +95,13 @@ def test_read_period_limits_contract_window(monkeypatch):
     start = pd.Timestamp("2025-09-20T00:00:00Z")
     end = pd.Timestamp("2025-10-20T00:00:00Z")
 
+    roll_date = start + pd.Timedelta(hours=1)
+
     period = RollPeriod(
         contract=contract,
         start=start,
         end=end,
-        roll_date=start,
+        roll_date=roll_date,
         expiry=end,
     )
 
@@ -115,3 +133,63 @@ def test_read_period_limits_contract_window(monkeypatch):
 
     # Metadata is preserved and only one contract is present for the window.
     assert set(df["Contract"].unique()) == {contract.contract_id}
+
+
+def test_export_scid_files_to_parquet(monkeypatch, tmp_path):
+    _parquet_exports.clear()
+
+    monkeypatch.setattr(asc, "FastScidReader", _DummyParquetFastReader)
+
+    reader = AsyncScidReader(tmp_path)
+
+    async def run_sync(func):
+        return func()
+
+    monkeypatch.setattr(reader, "_run_in_executor", run_sync)
+
+    source_a = tmp_path / "a.scid"
+    source_b = tmp_path / "b.scid"
+    # Ensure files exist so export proceeds
+    source_a.touch()
+    source_b.touch()
+
+    target_a = tmp_path / "out" / "a.parquet"
+    target_b = tmp_path / "nested" / "dir" / "b.parquet"
+
+    include_columns = ["Open", "Close"]
+
+    stats = asyncio.run(
+        reader.export_scid_files_to_parquet(
+            [(source_a, target_a), (source_b, target_b)],
+            start_ms=1,
+            end_ms=2,
+            include_columns=include_columns,
+            chunk_records=123,
+            compression="snappy",
+            include_time=False,
+            use_dictionary=True,
+        )
+    )
+
+    assert target_a.parent.exists()
+    assert target_b.parent.exists()
+
+    assert len(_parquet_exports) == 2
+
+    export_map = {Path(src): (src, dst, kwargs) for src, dst, kwargs in _parquet_exports}
+
+    call_a = export_map[source_a]
+    assert call_a[1] == str(target_a)
+    assert call_a[2]["start_ms"] == 1
+    assert call_a[2]["end_ms"] == 2
+    assert call_a[2]["include_columns"] == include_columns
+    assert call_a[2]["chunk_records"] == 123
+    assert call_a[2]["compression"] == "snappy"
+    assert call_a[2]["include_time"] is False
+    assert call_a[2]["use_dictionary"] is True
+
+    call_b = export_map[source_b]
+    assert call_b[1] == str(target_b)
+
+    assert stats[str(source_a)]["output"] == str(target_a)
+    assert stats[str(source_b)]["output"] == str(target_b)


### PR DESCRIPTION
## Summary
- add an asynchronous Parquet export helper to AsyncScidReader that leverages FastScidReader.export_to_parquet_optimized
- provide a synchronous ScidReader wrapper around the new export helper
- add unit coverage that verifies the asynchronous export workflow and argument forwarding

## Testing
- pytest tests/test_async_scid_reader.py

------
https://chatgpt.com/codex/tasks/task_e_69075a5961e8832a852a27a76ec4f766