### PR TITLE
Fix roll schedule handling and add roll convention controls

### DIFF
--- a/sierrapy/__init__.py
+++ b/sierrapy/__init__.py
@@ -17,6 +17,7 @@ __email__ = "your.email@example.com"
 from .client.dtc_client import DTCClient, DTCClientConfig
 from .parser.scid_parse import (
     FastScidReader,
+    RollConvention,
     RollPeriod,
     ScidTickerFileManager,
     ScidContractInfo,
@@ -52,5 +53,6 @@ __all__ = [
     "ScidTickerFileManager",
     "ScidContractInfo",
     "RollPeriod",
+    "RollConvention",
     "Schema",
 ]

--- a/sierrapy/parser/__init__.py
+++ b/sierrapy/parser/__init__.py
@@ -6,6 +6,7 @@ This module provides parsers for both SCID (intraday) and DLY (daily) file forma
 
 from .scid_parse import (
     FastScidReader,
+    RollConvention,
     RollPeriod,
     ScidTickerFileManager,
     ScidContractInfo,
@@ -41,6 +42,7 @@ __all__ = [
     "ScidTickerFileManager",
     "ScidContractInfo",
     "RollPeriod",
+    "RollConvention",
     "Schema",
 
     # DLY parsing


### PR DESCRIPTION
## Summary
- add a RollConvention enum and expose it through the async and sync SCID readers
- update roll schedule construction to avoid truncating at a contract's own roll date while keeping an opt-in legacy mode
- expand coverage to ensure data past the roll date is retained and schedules match the selected convention

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_69089b9c1018832a957c14d49617ed71