### PR TITLE
Add FastScidReader peek APIs and async preflight support

### DIFF
--- a/sierra_scid_peek.py
+++ b/sierra_scid_peek.py
@@ -1,0 +1,72 @@
+"""Lightweight utility to inspect Sierra Chart .scid files."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from sierrapy.parser.scid_parse import FastScidReader
+
+
+def _peek_file(path: Path) -> dict:
+    entry: dict = {"path": str(path)}
+    if not path.exists():
+        entry["error"] = "not found"
+        return entry
+
+    try:
+        with FastScidReader(str(path), read_only=True).open() as reader:
+            try:
+                n, start, end = reader.peek_range()
+            except AttributeError:
+                n = reader.count
+                if n == 0:
+                    start = end = None
+                else:
+                    times = reader.times_epoch_ms()
+                    start = int(times[0])
+                    end = int(times[-1])
+    except Exception as exc:  # pragma: no cover - defensive
+        entry["error"] = str(exc)
+        return entry
+
+    entry.update({"count": n, "start": start, "end": end})
+    return entry
+
+
+def _gather_paths(root: Path, pattern: Optional[str]) -> Sequence[Path]:
+    if root.is_dir():
+        glob = pattern or "*.scid"
+        return sorted(root.glob(glob))
+    return [root]
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Peek at SCID timestamp ranges")
+    parser.add_argument("path", help="Path to a .scid file or directory")
+    parser.add_argument("--glob", help="Glob when --path is a directory")
+    parser.add_argument("--json", action="store_true", help="Emit JSON output")
+    args = parser.parse_args(argv)
+
+    targets = _gather_paths(Path(args.path), args.glob)
+
+    results: List[dict] = [_peek_file(path) for path in targets]
+
+    if args.json:
+        payload = results[0] if len(results) == 1 else results
+        print(json.dumps(payload))
+    else:
+        for result in results:
+            if "error" in result:
+                print(f"{result['path']}: error={result['error']}")
+            else:
+                print(
+                    f"{result['path']}: count={result['count']} start={result['start']} end={result['end']}"
+                )
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/sierrapy/parser/async_scid_reader.py
+++ b/sierrapy/parser/async_scid_reader.py
@@ -126,6 +126,7 @@ class AsyncScidReader:
         resample_rule: Optional[str] = None,
         resample_kwargs: Optional[Dict[str, Any]] = None,
         drop_invalid_rows: bool = False,
+        preflight_peek: bool = False,
 
     ) -> "pd.DataFrame":
         frame_pd = _ensure_pandas()
@@ -153,6 +154,42 @@ class AsyncScidReader:
 
         if not periods:
             return frame_pd.DataFrame()
+
+        if preflight_peek:
+            filtered_periods: List[RollPeriod] = []
+            for period in periods:
+                try:
+                    with FastScidReader(str(period.contract.file_path), read_only=True).open() as reader:
+                        try:
+                            count, first_ms, last_ms = reader.peek_range()
+                        except AttributeError:
+                            times = reader.times_epoch_ms()
+                            count = len(times)
+                            if count == 0:
+                                first_ms = last_ms = None
+                            else:
+                                first_ms = int(times[0])
+                                last_ms = int(times[-1])
+                except Exception:
+                    filtered_periods.append(period)
+                    continue
+
+                if count == 0 or first_ms is None or last_ms is None:
+                    continue
+
+                period_start_ms = _timestamp_to_epoch_ms(period.start)
+                period_end_ms_exclusive = _timestamp_to_epoch_ms(period.end)
+
+                if period_end_ms_exclusive is not None and first_ms >= period_end_ms_exclusive:
+                    continue
+                if period_start_ms is not None and last_ms < period_start_ms:
+                    continue
+
+                filtered_periods.append(period)
+            periods = filtered_periods
+
+            if not periods:
+                return frame_pd.DataFrame()
 
         tasks = [
             self._read_period(
@@ -187,6 +224,40 @@ class AsyncScidReader:
 
         combined.index.name = "DateTime"
         return combined
+
+    def enumerate_front_month_contracts(
+        self,
+        ticker: str,
+        *,
+        start: Optional[Union["pd.Timestamp", datetime, str]] = None,
+        end: Optional[Union["pd.Timestamp", datetime, str]] = None,
+        roll_offset: Optional["pd.DateOffset"] = None,
+        roll_convention: Union[RollConvention, str, None] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return metadata describing the generated front-month schedule."""
+
+        periods = self.generate_roll_schedule(
+            ticker,
+            start=start,
+            end=end,
+            roll_offset=roll_offset,
+            roll_convention=roll_convention,
+        )
+
+        results: List[Dict[str, Any]] = []
+        for period in periods:
+            results.append(
+                {
+                    "contract": period.contract.contract_id,
+                    "file": str(period.contract.file_path),
+                    "start": _ensure_utc(period.start),
+                    "end": _ensure_utc(period.end),
+                    "roll_date": _ensure_utc(period.roll_date),
+                    "expiry": _ensure_utc(period.expiry),
+                }
+            )
+
+        return results
 
     async def load_scid_files(
         self,
@@ -510,6 +581,7 @@ class ScidReader:
         resample_rule: Optional[str] = None,
         resample_kwargs: Optional[Dict[str, Any]] = None,
         drop_invalid_rows: bool = False,
+        preflight_peek: bool = False,
     ) -> "pd.DataFrame":
         """Load front-month series synchronously (handles asyncio internally)."""
         return asyncio.run(
@@ -526,6 +598,7 @@ class ScidReader:
                 resample_rule=resample_rule,
                 resample_kwargs=resample_kwargs,
                 drop_invalid_rows=drop_invalid_rows,
+                preflight_peek=preflight_peek,
             )
         )
 

--- a/tests/test_fastscid_peek.py
+++ b/tests/test_fastscid_peek.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from sierrapy.parser.scid_parse import FastScidReader
+
+from tests.utils_scid import write_scid_file
+
+
+@pytest.fixture
+def scid_path(tmp_path: Path) -> Path:
+    timestamps = [1_700_000_000_000, 1_700_000_001_000, 1_700_000_002_000]
+    return write_scid_file(tmp_path, "sample.scid", timestamps)
+
+
+def test_peek_real_file(tmp_path: Path) -> None:
+    timestamps = [1_700_000_000_000, 1_700_000_050_000, 1_700_000_100_000]
+    path = write_scid_file(tmp_path, "peek.scid", timestamps)
+
+    with FastScidReader(str(path), read_only=True).open() as reader:
+        count, start, end = reader.peek_range()
+
+        assert count == len(timestamps)
+        assert start == timestamps[0]
+        assert end == timestamps[-1]
+        assert reader.read_timestamp(0) == start
+        assert reader.read_timestamp(-1) == end
+
+        assert reader._timestamps_view is not None  # sanity: attribute populated
+        dt_field = reader.view["DateTime"]
+        assert np.shares_memory(reader._timestamps_view, dt_field)
+
+
+def test_read_timestamp_bounds(scid_path: Path) -> None:
+    with FastScidReader(str(scid_path), read_only=True).open() as reader:
+        with pytest.raises(IndexError):
+            reader.read_timestamp(3)
+        with pytest.raises(IndexError):
+            reader.read_timestamp(-4)
+
+
+def test_peek_empty_file(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.scid"
+    empty.write_bytes(b"")
+    reader = FastScidReader(str(empty), read_only=True)
+
+    with pytest.raises(ValueError):
+        reader.open()
+
+
+def test_peek_missing_file(tmp_path: Path) -> None:
+    reader = FastScidReader(str(tmp_path / "missing.scid"), read_only=True)
+    with pytest.raises(FileNotFoundError):
+        reader.open()
+
+
+@pytest.mark.skipif("SCID_PATH" not in os.environ, reason="SCID_PATH not configured")
+def test_peek_range_integration() -> None:
+    path = Path(os.environ["SCID_PATH"])
+    with FastScidReader(str(path), read_only=True).open() as reader:
+        count, start, end = reader.peek_range()
+
+        assert count >= 0
+        if count == 0:
+            assert start is None and end is None
+        else:
+            assert start is not None and end is not None and start <= end
+            assert reader.read_timestamp(0) == start
+            assert reader.read_timestamp(-1) == end

--- a/tests/test_front_month_enumeration.py
+++ b/tests/test_front_month_enumeration.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from sierrapy.parser.async_scid_reader import AsyncScidReader
+from sierrapy.parser.scid_parse import RollPeriod, ScidContractInfo
+
+
+def _period(contract_id: str, start: str, end: str, path: Path) -> RollPeriod:
+    ticker = "NG"
+    month = contract_id[0]
+    year = 2000 + int(contract_id[1:])
+    contract = ScidContractInfo(
+        ticker=ticker,
+        month=month,
+        year=year,
+        exchange="NYM",
+        file_path=path,
+    )
+    start_ts = pd.Timestamp(start, tz="UTC")
+    end_ts = pd.Timestamp(end, tz="UTC")
+    return RollPeriod(
+        contract=contract,
+        start=start_ts,
+        end=end_ts,
+        roll_date=start_ts + pd.Timedelta(days=1),
+        expiry=end_ts,
+    )
+
+
+def test_enumerate_front_month_contracts(monkeypatch, tmp_path: Path) -> None:
+    reader = AsyncScidReader(tmp_path)
+    periods = [
+        _period("Z25", "2025-10-01T00:00:00Z", "2025-11-01T00:00:00Z", tmp_path / "one.scid"),
+        _period("F26", "2025-11-01T00:00:00Z", "2025-12-01T00:00:00Z", tmp_path / "two.scid"),
+    ]
+
+    monkeypatch.setattr(reader, "generate_roll_schedule", lambda *_, **__: periods)
+
+    result = reader.enumerate_front_month_contracts("NG")
+    assert len(result) == 2
+
+    for idx, row in enumerate(result):
+        period = periods[idx]
+        assert row["contract"] == period.contract.contract_id
+        assert row["file"] == str(period.contract.file_path)
+        assert row["start"] == period.start.tz_convert("UTC")
+        assert row["end"] == period.end.tz_convert("UTC")
+        assert row["start"] < row["end"]

--- a/tests/test_front_month_loading.py
+++ b/tests/test_front_month_loading.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+import pytest
+
+from sierrapy.parser import async_scid_reader as asc
+from sierrapy.parser.async_scid_reader import AsyncScidReader
+from sierrapy.parser.scid_parse import RollPeriod, ScidContractInfo
+
+
+_TO_PANDAS_CALLS: List[str] = []
+_PEEK_RANGES: Dict[str, tuple[int, int, int]] = {}
+
+
+def _epoch_ms(ts: str) -> int:
+    return int(pd.Timestamp(ts, tz="UTC").value // 1_000_000)
+
+
+class _PeekFastReader:
+    def __init__(self, path: str, **_: object) -> None:
+        self.path = path
+
+    def open(self) -> "_PeekFastReader":
+        return self
+
+    def __enter__(self) -> "_PeekFastReader":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def peek_range(self) -> tuple[int, int | None, int | None]:
+        return _PEEK_RANGES[self.path]
+
+    def to_pandas(self, *, start_ms=None, end_ms=None, **_: object) -> "pd.DataFrame":
+        _TO_PANDAS_CALLS.append(self.path)
+        index = pd.to_datetime(
+            ["2025-01-01T12:00:00Z", "2025-01-01T18:00:00Z"], utc=True
+        )
+        data = {"Close": [1.0, 1.5]}
+        frame = pd.DataFrame(data, index=index)
+        frame.index.name = "DateTime"
+        return frame
+
+
+@pytest.fixture(autouse=True)
+def _reset_globals() -> None:
+    _TO_PANDAS_CALLS.clear()
+    _PEEK_RANGES.clear()
+
+
+@pytest.fixture
+def _schedule(tmp_path: Path) -> List[RollPeriod]:
+    contract_a = ScidContractInfo("NG", "Z", 2025, "NYM", tmp_path / "a.scid")
+    contract_b = ScidContractInfo("NG", "F", 2026, "NYM", tmp_path / "b.scid")
+
+    period_a = RollPeriod(
+        contract=contract_a,
+        start=pd.Timestamp("2025-01-01T00:00:00Z"),
+        end=pd.Timestamp("2025-02-01T00:00:00Z"),
+        roll_date=pd.Timestamp("2025-01-15T00:00:00Z"),
+        expiry=pd.Timestamp("2025-02-01T00:00:00Z"),
+    )
+    period_b = RollPeriod(
+        contract=contract_b,
+        start=pd.Timestamp("2025-03-01T00:00:00Z"),
+        end=pd.Timestamp("2025-04-01T00:00:00Z"),
+        roll_date=pd.Timestamp("2025-03-15T00:00:00Z"),
+        expiry=pd.Timestamp("2025-04-01T00:00:00Z"),
+    )
+
+    _PEEK_RANGES[str(contract_a.file_path)] = (
+        10,
+        _epoch_ms("2025-01-01T00:00:00Z"),
+        _epoch_ms("2025-01-02T00:00:00Z"),
+    )
+    _PEEK_RANGES[str(contract_b.file_path)] = (
+        5,
+        _epoch_ms("2025-01-01T00:00:00Z"),
+        _epoch_ms("2025-01-10T00:00:00Z"),
+    )
+
+    return [period_a, period_b]
+
+
+def test_preflight_skips_non_overlapping(monkeypatch, tmp_path: Path, _schedule: List[RollPeriod]) -> None:
+    reader = AsyncScidReader(tmp_path)
+
+    monkeypatch.setattr(asc, "FastScidReader", _PeekFastReader)
+
+    async def run_sync(func):
+        return func()
+
+    monkeypatch.setattr(reader, "_run_in_executor", run_sync)
+    monkeypatch.setattr(reader._manager, "generate_roll_schedule", lambda *_, **__: _schedule)
+
+    baseline = asyncio.run(
+        reader.load_front_month_series(
+            "NG",
+            include_metadata=False,
+            preflight_peek=False,
+        )
+    )
+    baseline_calls = list(_TO_PANDAS_CALLS)
+
+    _TO_PANDAS_CALLS.clear()
+
+    optimized = asyncio.run(
+        reader.load_front_month_series(
+            "NG",
+            include_metadata=False,
+            preflight_peek=True,
+        )
+    )
+    optimized_calls = list(_TO_PANDAS_CALLS)
+
+    pd.testing.assert_frame_equal(baseline, optimized)
+
+    assert len(baseline_calls) == 2
+    assert len(optimized_calls) == 1
+    assert optimized_calls[0] == str(_schedule[0].contract.file_path)

--- a/tests/test_scid_peek_cli.py
+++ b/tests/test_scid_peek_cli.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.utils_scid import write_scid_file
+
+
+def test_scid_peek_cli_json(tmp_path: Path) -> None:
+    timestamps = [1_700_000_000_000, 1_700_000_010_000]
+    path = write_scid_file(tmp_path, "cli.scid", timestamps)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "sierra_scid_peek", str(path), "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["path"].endswith("cli.scid")
+    assert payload["count"] == len(timestamps)
+    assert payload["start"] == timestamps[0]
+    assert payload["end"] == timestamps[-1]

--- a/tests/utils_scid.py
+++ b/tests/utils_scid.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from sierrapy.parser.scid_parse import DTYPE_V10_40B
+
+_SC_EPOCH_OFFSET_US = 25569 * 86400 * 1_000_000
+
+
+def write_scid_file(directory: Path, name: str, timestamps_ms: Sequence[int]) -> Path:
+    path = directory / name
+    arr = np.zeros(len(timestamps_ms), dtype=DTYPE_V10_40B)
+    if timestamps_ms:
+        arr["DateTime"] = np.asarray(timestamps_ms, dtype=np.int64) * 1000 + _SC_EPOCH_OFFSET_US
+        arr["Open"] = np.linspace(1.0, 1.0 + len(timestamps_ms) - 1, len(timestamps_ms), dtype=np.float32)
+        arr["High"] = arr["Open"]
+        arr["Low"] = arr["Open"]
+        arr["Close"] = arr["Open"]
+        arr["NumTrades"] = np.arange(1, len(timestamps_ms) + 1, dtype=np.uint32)
+        arr["TotalVolume"] = np.arange(10, 10 + 10 * len(timestamps_ms), 10, dtype=np.uint32)
+        arr["BidVolume"] = arr["TotalVolume"]
+        arr["AskVolume"] = arr["TotalVolume"]
+
+    path.write_bytes(arr.tobytes())
+    return path


### PR DESCRIPTION
## Summary
- add zero-copy timestamp accessors to `FastScidReader`, including `read_timestamp` and `peek_range`
- introduce a `sierra_scid_peek` CLI helper that surfaces the fast peek path with JSON output
- extend `AsyncScidReader`/`ScidReader` with optional `preflight_peek` filtering and enumeration helpers plus accompanying tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6908ac3fa600832a9e9d783341e03189