### PR TITLE
Ensure resampled Open derives from Close first value

### DIFF
--- a/sierrapy/parser/scid_parse.py
+++ b/sierrapy/parser/scid_parse.py
@@ -189,8 +189,14 @@ def _resample_ohlcv(
     if agg is None:
         agg = _default_ohlcv_aggregation(frame.columns)
 
+    open_from_close = None
+    if "Close" in frame.columns:
+        open_from_close = resampled["Close"].first()
+
     result = resampled.agg(agg)
     result.index.name = frame.index.name
+    if open_from_close is not None:
+        result["Open"] = open_from_close
     return result.dropna(how="all")
 
 

--- a/tests/test_resample_ohlcv.py
+++ b/tests/test_resample_ohlcv.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+from sierrapy.parser import resample_ohlcv
+
+
+def test_resample_open_from_close_first():
+    index = pd.date_range("2023-01-01", periods=4, freq="min")
+    frame = pd.DataFrame(
+        {
+            "Open": [0.0, 0.0, 0.0, 0.0],
+            "Close": [1.0, 2.0, 3.0, 4.0],
+        },
+        index=index,
+    )
+
+    result = resample_ohlcv(frame, "2min")
+
+    expected_index = pd.date_range("2023-01-01", periods=2, freq="2min")
+    expected = pd.DataFrame(
+        {
+            "Open": [1.0, 3.0],
+            "Close": [2.0, 4.0],
+        },
+        index=expected_index,
+    )
+
+    pd.testing.assert_index_equal(result.index, expected.index)
+    pd.testing.assert_series_equal(result["Open"], expected["Open"], check_names=False)
+    pd.testing.assert_series_equal(result["Close"], expected["Close"], check_names=False)


### PR DESCRIPTION
## Summary
- derive resampled Open values from the first Close observation in each period
- keep the Open column aligned with Close-first data even when source Open values are empty
- add unit test covering the Open-from-Close resampling behavior

## Testing
- pytest tests/test_resample_ohlcv.py

------
https://chatgpt.com/codex/tasks/task_e_6908c6481e98832ab4bb369318ef98c3